### PR TITLE
feat: Calibration of results

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -125,21 +125,35 @@ rule run_gbdispatchmodel_as_rule:
     output:
         networks_dispatch=expand(
             gbdispatchmodel(
-                "resources/GB-ETYS-subset/networks/HT/unconstrained_clustered/{planning_horizons}.nc"
+                "resources/GB-ETYS-subset/networks/{fes_scenario}/constrained_clustered/{planning_horizons}.nc"
             ),
+            fes_scenario=["HT", "CF"],
+            planning_horizons=["2030", "2040"],
+        ),
+        networks_redispatch=expand(
+            gbdispatchmodel(
+                "resources/GB-ETYS-subset/networks/{fes_scenario}/unconstrained_clustered/{planning_horizons}.nc"
+            ),
+            fes_scenario=["HT", "CF"],
             planning_horizons=["2030", "2040"],
         ),
         renewable_strike_prices=gbdispatchmodel(
             "resources/GB-ETYS-subset/gb-model/CfD_strike_prices.csv"
         ),
-        bid_offer_multipliers=gbdispatchmodel(
-            "resources/GB-ETYS-subset/gb-model/HT/bid_offer_multipliers.csv"
+        bid_offer_multipliers=expand(
+            gbdispatchmodel(
+                "resources/GB-ETYS-subset/gb-model/{fes_scenario}/bid_offer_multipliers.csv"
+            ),
+            fes_scenario=["HT", "CF"],
         ),
         current_etys_caps=gbdispatchmodel(
             "resources/GB-ETYS-subset/gb-model/etys_boundary_capabilities.csv"
         ),
-        future_etys_caps=gbdispatchmodel(
-            "resources/GB-ETYS-subset/gb-model/HT/future_etys_boundary_capabilities.csv"
+        future_etys_caps=expand(
+            gbdispatchmodel(
+                "resources/GB-ETYS-subset/gb-model/{fes_scenario}/future_etys_boundary_capabilities.csv"
+            ),
+            fes_scenario=["HT", "CF"],
         ),
         boundary_crossings=gbdispatchmodel(
             "resources/GB-ETYS-subset/etys_boundary_crossings.csv"
@@ -203,7 +217,7 @@ rule prepare_scenario_IEM:
         # Use inputs from both models with fixed capacities before they are passed to
         # the optimal dispatch run
         gb_model=gbdispatchmodel(
-            "resources/GB-ETYS-subset/networks/HT/unconstrained_clustered/{planning_horizons}.nc"
+            "resources/GB-ETYS-subset/networks/{config['fes_scenario']}/unconstrained_clustered/{planning_horizons}.nc"
         ),
         iem_model=ngviemmodel(
             "results/ngv-iem/latest/networks/base_s_all___{planning_horizons}_no_ce.nc",
@@ -391,7 +405,7 @@ rule prepare_redispatch:
             "resources/GB-ETYS-subset/gb-model/CfD_strike_prices.csv"
         ),
         bids_and_offers=gbdispatchmodel(
-            "resources/GB-ETYS-subset/gb-model/HT/bid_offer_multipliers.csv"
+            "resources/GB-ETYS-subset/gb-model/CF/bid_offer_multipliers.csv"
         ),
     output:
         network="resources/redispatch/networks/{scenario}/{planning_horizons}.nc",
@@ -429,7 +443,7 @@ rule solve_redispatch:
         future_etys_caps=branch(
             config["etys"]["use_future_capacities"],
             gbdispatchmodel(
-                "resources/GB-ETYS-subset/gb-model/HT/future_etys_boundary_capabilities.csv"
+                "resources/GB-ETYS-subset/gb-model/CF/future_etys_boundary_capabilities.csv"
             ),
             [],
         ),

--- a/Snakefile
+++ b/Snakefile
@@ -378,7 +378,9 @@ rule calc_interconnector_bid_offer_profile:
     message:
         "Calculate interconnector bid/offer profiles"
     input:
-        bids_and_offers=rules.run_gbdispatchmodel_as_rule.output.bid_offer_multipliers,
+        bids_and_offers=gbdispatchmodel(
+            f"resources/GB-ETYS-subset/gb-model/{config['fes_scenario']}/bid_offer_multipliers.csv"
+        ),
         unconstrained_result="results/dispatch/networks/{scenario}/{planning_horizons}.nc",
     output:
         bid_offer_profile="resources/redispatch/interconnector_bid_offer_profile/{scenario}/{planning_horizons}.csv",
@@ -406,7 +408,7 @@ rule prepare_redispatch:
             "resources/GB-ETYS-subset/gb-model/CfD_strike_prices.csv"
         ),
         bids_and_offers=gbdispatchmodel(
-            "resources/GB-ETYS-subset/gb-model/CF/bid_offer_multipliers.csv"
+            f"resources/GB-ETYS-subset/gb-model/{config['fes_scenario']}/bid_offer_multipliers.csv"
         ),
     output:
         network="resources/redispatch/networks/{scenario}/{planning_horizons}.nc",
@@ -444,7 +446,7 @@ rule solve_redispatch:
         future_etys_caps=branch(
             config["etys"]["use_future_capacities"],
             gbdispatchmodel(
-                "resources/GB-ETYS-subset/gb-model/CF/future_etys_boundary_capabilities.csv"
+                f"resources/GB-ETYS-subset/gb-model/{config['fes_scenario']}/future_etys_boundary_capabilities.csv"
             ),
             [],
         ),

--- a/Snakefile
+++ b/Snakefile
@@ -401,6 +401,10 @@ rule prepare_redispatch:
     input:
         network="resources/base/networks/{scenario}/{planning_horizons}.nc",
         dispatch_result=rules.solve_dispatch.output.network,
+        iem_network=branch(
+            lambda wildcards: wildcards.scenario in ["SQ"],
+            rules.prepare_scenario_IEM.output.model,
+        ),
         interconnector_bid_offer=rules.calc_interconnector_bid_offer_profile.output.bid_offer_profile,
         boundary_crossings="config/boundary_definitions.yaml",
         # Unchanged from GB dispatch model

--- a/Snakefile
+++ b/Snakefile
@@ -217,7 +217,7 @@ rule prepare_scenario_IEM:
         # Use inputs from both models with fixed capacities before they are passed to
         # the optimal dispatch run
         gb_model=gbdispatchmodel(
-            "resources/GB-ETYS-subset/networks/{config['fes_scenario']}/unconstrained_clustered/{planning_horizons}.nc"
+            f"resources/GB-ETYS-subset/networks/{config['fes_scenario']}/unconstrained_clustered/{{planning_horizons}}.nc"
         ),
         iem_model=ngviemmodel(
             "results/ngv-iem/latest/networks/base_s_all___{planning_horizons}_no_ce.nc",

--- a/Snakefile
+++ b/Snakefile
@@ -125,19 +125,7 @@ rule run_gbdispatchmodel_as_rule:
     output:
         networks_dispatch=expand(
             gbdispatchmodel(
-                "resources/GB-ETYS-subset/networks/HT/constrained_clustered/{planning_horizons}.nc"
-            ),
-            planning_horizons=["2030", "2040"],
-        ),
-        networks_redispatch=expand(
-            gbdispatchmodel(
                 "resources/GB-ETYS-subset/networks/HT/unconstrained_clustered/{planning_horizons}.nc"
-            ),
-            planning_horizons=["2030", "2040"],
-        ),
-        results_dispatch=expand(
-            gbdispatchmodel(
-                "results/GB-ETYS-subset/networks/HT/unconstrained_clustered/{planning_horizons}.nc"
             ),
             planning_horizons=["2030", "2040"],
         ),

--- a/Snakefile
+++ b/Snakefile
@@ -213,6 +213,7 @@ rule prepare_scenario_IEM:
     params:
         carrier_map=config["carrier_mapping"],
         time_aggregation=config["time_aggregation"],
+        capacity_multipliers=config["calibration"]["capacity_multipliers"],
     input:
         # Use inputs from both models with fixed capacities before they are passed to
         # the optimal dispatch run

--- a/Snakefile
+++ b/Snakefile
@@ -90,9 +90,9 @@ rule run_phase01_model_as_rule:
         offshore_zone_trajectories=ngviemmodel(
             "resources/ngv-iem/latest/offshore_zone_trajectories.csv"
         ),
-        # results_noce_2040=ngviemmodel(
-        #     "results/ngv-iem/latest/networks/base_s_all___2040_no_ce.nc"
-        # ),
+        results_noce_2040=ngviemmodel(
+            "results/ngv-iem/latest/networks/base_s_all___2040_no_ce.nc"
+        ),
     shell:
         """
         pixi run \

--- a/Snakefile
+++ b/Snakefile
@@ -269,10 +269,10 @@ rule retrieve_data_FBMC:
     message:
         "Retrieving data for flow-based market coupling for year {wildcards.planning_horizons} (scenario: FBMC - flow-based market coupling)."
     input:
-        flow_based_constraints="data/NGV-FBMC/primary/20260326/flow_based_constraints_{planning_horizons}.parquet",
+        flow_based_constraints="data/NGV-FBMC/primary/20260421/flow_based_constraints_{planning_horizons}.parquet",
     output:
-        ptdf="data/NGV-FBMC/primary/20260326/ptdf/{planning_horizons}.nc",
-        ram="data/NGV-FBMC/primary/20260326/ram/{planning_horizons}.nc",
+        ptdf="data/NGV-FBMC/primary/20260421/ptdf/{planning_horizons}.nc",
+        ram="data/NGV-FBMC/primary/20260421/ram/{planning_horizons}.nc",
     log:
         "logs/retrieve_data_FBMC/{planning_horizons}.log",
     run:

--- a/config/config.gb-dispatch.yaml
+++ b/config/config.gb-dispatch.yaml
@@ -9,6 +9,6 @@ renewable:
   "offwind-dc":
     correction_factor: 0.70840 # 80% of default 0.8855 to align with reported FES2024 load factors
 
-# Need an entry such that Snakemake considers this a valid yaml file
-# Can be removed once there are other actual entries in this file
-place: holder
+dukes-fuel-prices:
+  sheet-config:
+    skiprows: 15 # Fix - currently necessary as data contains an unexpected comment row.

--- a/config/config.gb-dispatch.yaml
+++ b/config/config.gb-dispatch.yaml
@@ -6,8 +6,10 @@
 # coming from the gb-dispatch-model.
 
 renewable:
+  onwind:
+    correction_factor: 0.8 # 80% of default 1 to align with reported FES2024 load factors
   "offwind-dc":
-    correction_factor: 0.70840 # 80% of default 0.8855 to align with reported FES2024 load factors
+    correction_factor: 0.664125 # 75% of default 0.8855 to align with reported FES2024 load factors
 
 dukes-fuel-prices:
   sheet-config:

--- a/config/config.gb-dispatch.yaml
+++ b/config/config.gb-dispatch.yaml
@@ -5,6 +5,10 @@
 # Contains additional configuration options that overwrite the defaults
 # coming from the gb-dispatch-model.
 
+renewable:
+  "offwind-dc":
+    correction_factor: 0.70840 # 80% of default 0.8855 to align with reported FES2024 load factors
+
 # Need an entry such that Snakemake considers this a valid yaml file
 # Can be removed once there are other actual entries in this file
 place: holder

--- a/config/config.ngv-fbmc.yaml
+++ b/config/config.ngv-fbmc.yaml
@@ -13,6 +13,19 @@ scenarios:
 
 fes_scenario: HT # or CF
 
+calibration:
+  capacity_multipliers:
+    # These multipliers are only applied to capacities in the GB model.
+    # They scale the nameplate capacity of generators with the matching carrier
+    # Currently only applied to "Generator" components
+    offwind-dc:
+      # Multipliers selected for sensitivity
+      2030: 1.0
+      2040: 1.0
+    onwind:
+      2030: 1.0
+      2040: 1.0
+
 planning_horizons:
 - 2030
 - 2040

--- a/config/config.ngv-fbmc.yaml
+++ b/config/config.ngv-fbmc.yaml
@@ -256,6 +256,10 @@ solving:
     threads: 8
     gurobi-default:
       BarConvTol: 1.e-6
+      NumericFocus: 0
+      MemLimit: 50
+      PreSparsify: 2
+      Presolve: 2
       IISMethod: 1
     cplex-default:
       barrier.convergetol: 1.e-6

--- a/config/config.ngv-fbmc.yaml
+++ b/config/config.ngv-fbmc.yaml
@@ -183,6 +183,7 @@ carrier_mapping:
     Residential Heat DSR shift: battery charger
     Residential Heat unmanaged load: electricity distribution grid
     EV V2G: home battery discharger
+    Transmission-level + T&D losses unmanaged load: electricity distribution grid
   Load:
     AC: electricity
     Baseline Electricity: electricity
@@ -190,6 +191,7 @@ carrier_mapping:
     H2: H2 exogenous demand
     I&C Heat: electricity
     Residential Heat: electricity
+    Transmission-level + T&D losses: electricity
   StorageUnit:
     Battery Storage: battery
     PHS: hydro-phs

--- a/config/config.ngv-fbmc.yaml
+++ b/config/config.ngv-fbmc.yaml
@@ -11,6 +11,8 @@ scenarios:
 - SQ
 - FBMC
 
+fes_scenario: HT # or CF
+
 planning_horizons:
 - 2030
 - 2040

--- a/config/config.ngv-fbmc.yaml
+++ b/config/config.ngv-fbmc.yaml
@@ -257,7 +257,6 @@ solving:
     gurobi-default:
       BarConvTol: 1.e-6
       NumericFocus: 0
-      MemLimit: 50
       PreSparsify: 2
       Presolve: 2
       IISMethod: 1

--- a/scripts/fbmc.py
+++ b/scripts/fbmc.py
@@ -8,6 +8,7 @@ from typing import Self
 
 import pandas as pd
 import pypsa
+import numpy as np
 import xarray as xr
 
 logger = logging.getLogger(__name__)
@@ -32,6 +33,11 @@ class FBMCConstraint:
             .stack()
         )
         ram = xr.DataArray.from_series(df["ram"])
+
+        # PTDF and RAM values can have minor numerical deviations that can cause infeasibilities
+        # By rounding towards the next higher number, we mitigate this issue
+        ram = np.ceil(ram)
+        ptdf = np.ceil(ptdf)
 
         return cls(ptdf, ram)
 

--- a/scripts/prepare_redispatch.py
+++ b/scripts/prepare_redispatch.py
@@ -1071,12 +1071,59 @@ def convert_boundary_crossings(
         )
 
 
+def reset_interconnector_operating_limits(
+    network: pypsa.Network, network_ref: pypsa.Network
+) -> pypsa.Network:
+    """
+    For the SQ scenario, reset the operating limits of the interconnectors to the original values in the reference network.
+
+    Whilst in the SQ dispatch scenario the interconnector operating limits are provided through the market outcomes,
+    in the redispatch case we want to be able to make full use of the interconnector capacities up to their technical limits.
+
+    Parameters
+    ----------
+    network: pypsa.Network
+        Network for which the interconnector limits will be reset.
+    network_ref: pypsa.Network
+        Reference network with the to-be-used interconnector limits.
+
+    Returns
+    -------
+    pypsa.Network
+        Network with reset interconnector limits.
+    """
+
+    interconnectors = filter_interconnectors(
+        network.c.links.static, "carrier in ['DC']"
+    ).index
+    interconnectors_ref = filter_interconnectors(
+        network_ref.c.links.static, "carrier in ['DC']"
+    ).index
+    logger.info(
+        f"Resetting operating limits for {len(interconnectors)} interconnectors to the original values in the reference network"
+    )
+
+    if not interconnectors.equals(interconnectors_ref):
+        raise ValueError(
+            "Not all interconnectors in the network are present in the reference network. Cannot reset operating limits."
+        )
+
+    network.c.links.dynamic.p_min_pu.loc[:, interconnectors] = (
+        network_ref.c.links.dynamic.p_min_pu.loc[:, interconnectors_ref]
+    )
+    network.c.links.dynamic.p_max_pu.loc[:, interconnectors] = (
+        network_ref.c.links.dynamic.p_max_pu.loc[:, interconnectors_ref]
+    )
+
+    return network
+
+
 if __name__ == "__main__":
     if "snakemake" not in globals():
         from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
-            Path(__file__).stem, planning_horizons=2030, scenario="IEM"
+            Path(__file__).stem, planning_horizons=2030, scenario="SQ"
         )
 
     configure_logging(snakemake)
@@ -1133,6 +1180,19 @@ if __name__ == "__main__":
     network = fix_dispatch(
         base_network=network, dispatch_result=dispatch_result, gb_buses=gb_buses
     )
+
+    # SQ scenario only:
+    # Because we use different p_min_pu and p_max_pu limits for the interconnectors,
+    # and we use the dispatch network and the base network for calculations,
+    # we reset both of their operating limits to match the original technical limits
+    # before we calculate e.g. ramp up / ramp down rates
+    if snakemake.wildcards.scenario == "SQ":
+        network = reset_interconnector_operating_limits(
+            network, network_ref=pypsa.Network(snakemake.input.iem_network)
+        )
+        dispatch_result = reset_interconnector_operating_limits(
+            dispatch_result, network_ref=pypsa.Network(snakemake.input.iem_network)
+        )
 
     network = create_up_down_plants(
         base_network=network,

--- a/scripts/prepare_scenario_IEM.py
+++ b/scripts/prepare_scenario_IEM.py
@@ -784,8 +784,11 @@ if __name__ == "__main__":
     )
 
     # Patch: This Link was not originally in the data; unclear where it is coming from
-    # but it is not supposed to be here. Manually cleaned up until fixed upstream
-    n_gb.remove("Link", "relation/15777152-320-DC+1")
+    # but it is not supposed to be here. Manually cleaned up until fixed upstream.
+    # Might be related to clustering not working fully deterministically.
+    if "relation/15777152-320-DC+1" in n_gb.c["Link"].static.index:
+        n_gb.remove("Link", "relation/15777152-320-DC+1")
+        logger.info("Removed unexpected Link relation/15777152-320-DC+1 from GB model")
 
     # Merge the two networks
     n_merged = merge_gb_tyndp(n_gb.copy(), n_eur.copy(), carrier_map)

--- a/scripts/prepare_scenario_IEM.py
+++ b/scripts/prepare_scenario_IEM.py
@@ -715,6 +715,30 @@ def patch_OH_interconnector_capacities(
     return n
 
 
+def modify_generation_capacities(
+    n: pypsa.Network, capacity_multipliers: dict[str, dict[int, float]], year: int
+) -> pypsa.Network:
+    """
+    Modifies the generation capacities in the GB model according to the specified multipliers.
+
+    Used for calibration to adjust the generation capacities in the GB model.
+    """
+    for carrier, multiplier in capacity_multipliers.items():
+        gens = n.c.generators.static.query(
+            "`carrier` == @carrier", local_dict={"carrier": carrier}
+        )
+
+        multiplier = multiplier[year]
+
+        logger.info(
+            f"Modifying generation capacities for {carrier} generators by a multiplier of {multiplier}: {gens.index.tolist()}"
+        )
+
+        n.c.generators.static.loc[gens.index, "p_nom"] *= multiplier
+
+    return n
+
+
 if __name__ == "__main__":
     if "snakemake" not in globals():
         from scripts._helpers import mock_snakemake
@@ -745,6 +769,13 @@ if __name__ == "__main__":
     # Reset networks before merging
     n_gb = reset_network(n_gb)
     n_eur = reset_network(n_eur)
+
+    # For calibration: Modify the generation capacities according to config multipliers
+    n_gb = modify_generation_capacities(
+        n=n_gb,
+        capacity_multipliers=snakemake.params.capacity_multipliers,
+        year=int(snakemake.wildcards.planning_horizons),
+    )
 
     # Patch: Interconnector capacities for stranded OH in openTYNDP. Fixed upstream with https://github.com/open-energy-transition/open-tyndp/pull/568
     # But that is not pulled into the project, so we do a manual patch here

--- a/scripts/prepare_scenario_IEM.py
+++ b/scripts/prepare_scenario_IEM.py
@@ -752,6 +752,10 @@ if __name__ == "__main__":
         n=n_eur, planning_horizon=int(snakemake.wildcards.planning_horizons)
     )
 
+    # Patch: This Link was not originally in the data; unclear where it is coming from
+    # but it is not supposed to be here. Manually cleaned up until fixed upstream
+    n_gb.remove("Link", "relation/15777152-320-DC+1")
+
     # Merge the two networks
     n_merged = merge_gb_tyndp(n_gb.copy(), n_eur.copy(), carrier_map)
 


### PR DESCRIPTION
This PR includes a range of calibrations that are necessary to align the model more closely with the FES 2024 HT scenario.

While the input data for the model is taken from FES2024, not all properties of FES2024 can be reproduced from the FES workbook. Some of the reported quantities reported in the workbook are themselves modelling results, e.g. the CF for offshore wind. In this specific case we artificially lower the availability rates, such that the CFs that are the output of our model are closer to the CFs reported in FES2024.