### PR TITLE
Add redispatch profit mitigation penalty to objective

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -401,6 +401,10 @@ rule prepare_redispatch:
     input:
         network="resources/base/networks/{scenario}/{planning_horizons}.nc",
         dispatch_result=rules.solve_dispatch.output.network,
+        iem_network=branch(
+            lambda wildcards: wildcards.scenario in ["SQ"],
+            rules.prepare_scenario_IEM.output.model,
+        ),
         interconnector_bid_offer=rules.calc_interconnector_bid_offer_profile.output.bid_offer_profile,
         boundary_crossings="config/boundary_definitions.yaml",
         # Unchanged from GB dispatch model

--- a/Snakefile
+++ b/Snakefile
@@ -441,6 +441,9 @@ rule solve_redispatch:
         # openTYNDP specific: Not used (because OH trajectories are off)
         # but keeping for consistency to be able to reuse code from the openTYNDP model
         renewable_carriers_tyndp=config["electricity"]["tyndp_renewable_carriers"],
+        redispatch_profit_mitigation_penalty=config["redispatch"][
+            "redispatch_profit_mitigation_penalty"
+        ],
         scenario=lambda w: w.scenario,
     input:
         network=rules.prepare_redispatch.output.network,

--- a/config/config.ngv-fbmc.yaml
+++ b/config/config.ngv-fbmc.yaml
@@ -32,6 +32,7 @@ planning_horizons:
 
 redispatch:
   unconstrain_lines_and_links: true
+  redispatch_profit_mitigation_penalty: 1000  # EUR/MWh of redispatch, applied as positive irrespective of the redispatch direction
   no_redispatch_carriers:
   - nuclear
   - geothermal # No bid/offer multiplier and negligible capacity, so no redispatch for simplicity
@@ -49,7 +50,7 @@ redispatch:
   - H2 Store
   - h2-ccgt
   # These carriers from the phase1 / openTYNDP model
-  # We add them here to suppress warnings - due to the logic they will not be added to 
+  # We add them here to suppress warnings - due to the logic they will not be added to
   # the model anyway, but it makes for a clearer log file
   - H2 import Pipeline
   - H2 pipeline

--- a/scripts/gb_model/redispatch/custom_constraints.py
+++ b/scripts/gb_model/redispatch/custom_constraints.py
@@ -164,14 +164,16 @@ def add_redispatch_penalty(n: pypsa.Network, snakemake: Snakemake) -> None:
         n (pypsa.Network): The PyPSA network to update.
         snakemake (snakemake.Snakemake): The snakemake object for parameters and config.
     """
-    idx = n.generators.filter(regex="ramp (up|down)").index
+    idx = n.generators.filter(regex="ramp (up|down)", axis=0).index
     is_neg = n.get_switchable_as_dense("Generator", "p_min_pu")[idx] < 0
     penalty = snakemake.params.redispatch_profit_mitigation_penalty
     obj_cost = is_neg.replace({True: -penalty, False: penalty}).stack().to_xarray()
     gen_p = n.model["Generator-p"].sel(**obj_cost.coords)
     n.model.objective += (obj_cost * gen_p * n.snapshot_weightings["objective"]).sum()
     logger.info(
-        f"Added redispatch penalty of {penalty} EUR/MWh to the objective function to mitigate profit manipulation."
+        f"Added redispatch penalty of {penalty} EUR/MWh to the following number of "
+        "redispatch generators in the objective function to mitigate profit manipulation:\n"
+        f"{n.generators.loc[idx].carrier.value_counts()}"
     )
 
 

--- a/scripts/gb_model/redispatch/custom_constraints.py
+++ b/scripts/gb_model/redispatch/custom_constraints.py
@@ -156,6 +156,25 @@ def update_storage_balance(n: pypsa.Network) -> None:
     )
 
 
+def add_redispatch_penalty(n: pypsa.Network, snakemake: Snakemake) -> None:
+    """
+    Add a penalty to the objective function for redispatching, irrespective of whether it's a bid or offer.
+
+    Args:
+        n (pypsa.Network): The PyPSA network to update.
+        snakemake (snakemake.Snakemake): The snakemake object for parameters and config.
+    """
+    idx = n.generators.filter(regex="ramp (up|down)").index
+    is_neg = n.get_switchable_as_dense("Generator", "p_min_pu")[idx] < 0
+    penalty = snakemake.params.redispatch_profit_mitigation_penalty
+    obj_cost = is_neg.replace({True: -penalty, False: penalty}).stack().to_xarray()
+    gen_p = n.model["Generator-p"].sel(**obj_cost.coords)
+    n.model.objective += (obj_cost * gen_p * n.snapshot_weightings["objective"]).sum()
+    logger.info(
+        f"Added redispatch penalty of {penalty} EUR/MWh to the objective function to mitigate profit manipulation."
+    )
+
+
 def custom_constraints(
     n: pypsa.Network,
     snapshots: pd.Index,
@@ -173,3 +192,4 @@ def custom_constraints(
     set_boundary_constraints(n, snapshots, snakemake)
     remove_KVL_constraints(n, snapshots, snakemake)
     update_storage_balance(n)
+    add_redispatch_penalty(n, snakemake)

--- a/scripts/prepare_redispatch.py
+++ b/scripts/prepare_redispatch.py
@@ -304,6 +304,11 @@ def create_up_down_plants(
                 # profiles take precedence
                 prices[direction].loc[:, prices_dynamic.columns] = prices_dynamic
 
+            # hacky fix for now 
+            storage_cols = prices['bid'].filter(regex="PHS|hydro|battery").columns
+            prices['bid'].loc[:, storage_cols] = 63
+            prices['offer'].loc[:,storage_cols] = 183
+
             # Bus to connect the up/down plants to, same for _up and _down
             bus = None
             if comp.name in ["Generator", "StorageUnit"]:

--- a/scripts/prepare_redispatch.py
+++ b/scripts/prepare_redispatch.py
@@ -1123,7 +1123,7 @@ if __name__ == "__main__":
         from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
-            Path(__file__).stem, planning_horizons=2030, scenario="IEM"
+            Path(__file__).stem, planning_horizons=2030, scenario="SQ"
         )
 
     configure_logging(snakemake)
@@ -1182,9 +1182,16 @@ if __name__ == "__main__":
     )
 
     # SQ scenario only:
+    # Because we use different p_min_pu and p_max_pu limits for the interconnectors,
+    # and we use the dispatch network and the base network for calculations,
+    # we reset both of their operating limits to match the original technical limits
+    # before we calculate e.g. ramp up / ramp down rates
     if snakemake.wildcards.scenario == "SQ":
         network = reset_interconnector_operating_limits(
             network, network_ref=pypsa.Network(snakemake.input.iem_network)
+        )
+        dispatch_result = reset_interconnector_operating_limits(
+            dispatch_result, network_ref=pypsa.Network(snakemake.input.iem_network)
         )
 
     network = create_up_down_plants(

--- a/scripts/prepare_redispatch.py
+++ b/scripts/prepare_redispatch.py
@@ -1071,6 +1071,53 @@ def convert_boundary_crossings(
         )
 
 
+def reset_interconnector_operating_limits(
+    network: pypsa.Network, network_ref: pypsa.Network
+) -> pypsa.Network:
+    """
+    For the SQ scenario, reset the operating limits of the interconnectors to the original values in the reference network.
+
+    Whilst in the SQ dispatch scenario the interconnector operating limits are provided through the market outcomes,
+    in the redispatch case we want to be able to make full use of the interconnector capacities up to their technical limits.
+
+    Parameters
+    ----------
+    network: pypsa.Network
+        Network for which the interconnector limits will be reset.
+    network_ref: pypsa.Network
+        Reference network with the to-be-used interconnector limits.
+
+    Returns
+    -------
+    pypsa.Network
+        Network with reset interconnector limits.
+    """
+
+    interconnectors = filter_interconnectors(
+        network.c.links.static, "carrier in ['DC']"
+    ).index
+    interconnectors_ref = filter_interconnectors(
+        network_ref.c.links.static, "carrier in ['DC']"
+    ).index
+    logger.info(
+        f"Resetting operating limits for {len(interconnectors)} interconnectors to the original values in the reference network"
+    )
+
+    if not interconnectors.equals(interconnectors_ref):
+        raise ValueError(
+            "Not all interconnectors in the network are present in the reference network. Cannot reset operating limits."
+        )
+
+    network.c.links.dynamic.p_min_pu.loc[:, interconnectors] = (
+        network_ref.c.links.dynamic.p_min_pu.loc[:, interconnectors_ref]
+    )
+    network.c.links.dynamic.p_max_pu.loc[:, interconnectors] = (
+        network_ref.c.links.dynamic.p_max_pu.loc[:, interconnectors_ref]
+    )
+
+    return network
+
+
 if __name__ == "__main__":
     if "snakemake" not in globals():
         from scripts._helpers import mock_snakemake
@@ -1133,6 +1180,12 @@ if __name__ == "__main__":
     network = fix_dispatch(
         base_network=network, dispatch_result=dispatch_result, gb_buses=gb_buses
     )
+
+    # SQ scenario only:
+    if snakemake.wildcards.scenario == "SQ":
+        network = reset_interconnector_operating_limits(
+            network, network_ref=pypsa.Network(snakemake.input.iem_network)
+        )
 
     network = create_up_down_plants(
         base_network=network,


### PR DESCRIPTION
Aim is to keep redispatch to a minimum. Any redispatch that isn't _strictly_ necessary (e.g. the model trying to sneakily create profit by redispatching two things simultaneously with favourable relative costs) will be wiped out by having a severe penalty applied to any attempt to redispatch.

This only appears in the linopy objective, so won't appear in any of the statistics later.